### PR TITLE
remove duplicate error field from error response

### DIFF
--- a/docs/Model/Error.md
+++ b/docs/Model/Error.md
@@ -4,7 +4,6 @@
 
 | Name        | Type                                              | Description | Notes      |
 | ----------- | ------------------------------------------------- | ----------- | ---------- |
-| **error**   | **string**                                        |             | [optional] |
 | **code**    | **int**                                           |             | [optional] |
 | **message** | **string**                                        |             | [optional] |
 | **details** | [**\Sajari\Model\ProtobufAny[]**](ProtobufAny.md) |             | [optional] |

--- a/lib/Model/Error.php
+++ b/lib/Model/Error.php
@@ -60,7 +60,6 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      * @var string[]
      */
     protected static $openAPITypes = [
-        "error" => "string",
         "code" => "int",
         "message" => "string",
         "details" => "\Sajari\Model\ProtobufAny[]",
@@ -74,7 +73,6 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      * @psalm-var array<string, string|null>
      */
     protected static $openAPIFormats = [
-        "error" => null,
         "code" => "int32",
         "message" => null,
         "details" => null,
@@ -107,7 +105,6 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      * @var string[]
      */
     protected static $attributeMap = [
-        "error" => "error",
         "code" => "code",
         "message" => "message",
         "details" => "details",
@@ -119,7 +116,6 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      * @var string[]
      */
     protected static $setters = [
-        "error" => "setError",
         "code" => "setCode",
         "message" => "setMessage",
         "details" => "setDetails",
@@ -131,7 +127,6 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      * @var string[]
      */
     protected static $getters = [
-        "error" => "getError",
         "code" => "getCode",
         "message" => "getMessage",
         "details" => "getDetails",
@@ -193,7 +188,6 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container["error"] = $data["error"] ?? null;
         $this->container["code"] = $data["code"] ?? null;
         $this->container["message"] = $data["message"] ?? null;
         $this->container["details"] = $data["details"] ?? null;
@@ -220,30 +214,6 @@ class Error implements ModelInterface, ArrayAccess, \JsonSerializable
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
-    }
-
-    /**
-     * Gets error
-     *
-     * @return string|null
-     */
-    public function getError()
-    {
-        return $this->container["error"];
-    }
-
-    /**
-     * Sets error
-     *
-     * @param string|null $error error
-     *
-     * @return self
-     */
-    public function setError($error)
-    {
-        $this->container["error"] = $error;
-
-        return $this;
     }
 
     /**

--- a/test/Model/ErrorTest.php
+++ b/test/Model/ErrorTest.php
@@ -80,15 +80,6 @@ class ErrorTest extends TestCase
     }
 
     /**
-     * Test attribute "error"
-     */
-    public function testPropertyError()
-    {
-        // TODO: implement
-        $this->markTestIncomplete("Not implemented");
-    }
-
-    /**
      * Test attribute "code"
      */
     public function testPropertyCode()


### PR DESCRIPTION
Users should use the message field instead, which was always available.